### PR TITLE
allow PRPACK to be compiled on clang (which does not support OpenMP yet)

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,7 +1,8 @@
 IGRAPH_SUPPORT ?= 0
+OPENMP_SUPPORT ?= 1
 
 CXX = g++
-CXXFLAGS = -Wall -g -fopenmp 
+CXXFLAGS = -Wall -g
 LDFLAGS =
 OBJS = prpack_utils.o \
     prpack_base_graph.o \
@@ -17,6 +18,12 @@ OBJS = prpack_utils.o \
     prpack_driver.o \
     prpack_driver_benchmark.o
 PROG = prpack_driver
+
+ifeq ($(OPENMP_SUPPORT),1)
+	CXXFLAGS += -fopenmp
+else
+	CXXFLAGS += -Wno-unknown-pragmas
+endif
 
 ifeq ($(IGRAPH_SUPPORT),1)
 	OBJS += prpack_igraph_graph.o

--- a/prpack_driver_benchmark.cpp
+++ b/prpack_driver_benchmark.cpp
@@ -12,13 +12,19 @@
  
 #include <math.h>
 #include <assert.h>
-#include <omp.h>
  
 #include <vector>
 #include <iostream>
 
 #include "prpack_base_graph.h"
 #include "prpack_solver.h"
+
+#ifdef _OPENMP
+#  include <omp.h>
+#else
+int omp_get_max_threads() { return 1; }
+void omp_set_num_threads(int) {}
+#endif
 
 using namespace std;
 


### PR DESCRIPTION
This patch updates `makefile` and `prpack_driver_benchmark.cpp` to enable compilation of PRPACK using `clang`, which does not support OpenMP extensions yet. The primary reason for this patch is that Mac OS X 10.9 ships `clang` as the default compiler (no `gcc`).

OpenMP support can be disabled by compiling PRPACK with `OPENMP_SUPPORT=0 make`; this will remove the `-fopenmp` flag from `CXXFLAGS` and add `-Wno-unknown-pragmas` instead to ask `clang` not to complain about the OpenMP pragmas.

Also, `omp.h` is now included conditionally in `prpack_driver_benchmark.cpp`. In the absence of OpenMP support, the file now provides fake implementations of `omp_get_max_threads` and `omp_set_num_threads`.
