### PR TITLE
fix assertion when converting from int64_csc to base_graph

### DIFF
--- a/prpack_base_graph.cpp
+++ b/prpack_base_graph.cpp
@@ -64,7 +64,7 @@ prpack_base_graph::prpack_base_graph(const prpack_csc* g) {
 prpack_base_graph::prpack_base_graph(const prpack_int64_csc* g) {
     initialize();
     // TODO remove the assert and add better behavior
-    assert(num_vs <= std::numeric_limits<int>::max());
+    assert(g->num_vs <= std::numeric_limits<int>::max());
     num_vs = (int)g->num_vs;
     num_es = (int)g->num_es;
     // fill in heads and tails


### PR DESCRIPTION
I think this is what was originally meant here.

I know this fix is somewhat pointless, but at least it eliminates some warnings from some static analysers.